### PR TITLE
Specify the params file and stack name using environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT-0
 S3_BUCKET ?= CONFIGURE_S3_BUCKET_HERE
 REGION ?= eu-west-1
+PARAMS_FILE ?= parameters.cfg
+STACK_NAME ?= automated-personalize-retraining
 
 all:
 	aws cloudformation package \
@@ -11,7 +13,7 @@ all:
 	aws cloudformation deploy \
 		--template-file packaged-template.yaml \
 		--s3-bucket $(S3_BUCKET) \
-		--stack-name automated-personalize-retraining \
+		--stack-name $(STACK_NAME) \
 		--capabilities CAPABILITY_IAM \
-		--parameter-overrides $$(cat parameters.cfg) \
+		--parameter-overrides $$(cat $(PARAMS_FILE)) \
 		--region $(REGION)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Once you have done the steps listed in the [Prerequisites](#Prerequisites), you 
 
 1. Fill in the S3 bucket you created for housing the deployment files, as well as the AWS Region to the first lines of the [Makefile](https://github.com/aws-samples/amazon-personalize-automated-retraining/blob/master/Makefile#L3-L4).
 2. Update the required parameters (e.g., ARNs from the datasets, retraining rate,...) in the [parameters.cfg](parameters.cfg). You'll find a list of all parameters and their description below.
-3. (Optional): You might want to adjust the (currently fixed) `--stack-name` from the [Makefile](https://github.com/aws-samples/amazon-personalize-automated-retraining/blob/master/Makefile#L14) in case you want to deploy multiple pipelines.
+3. (Optional): You might want to adjust the (currently fixed) `--stack-name` from the [Makefile](https://github.com/aws-samples/amazon-personalize-automated-retraining/blob/master/Makefile#L14) in case you want to deploy multiple pipelines. (See [Advanced use](#advanced-use))
 
 Now you can run `make` from your command line to deploy the pipeline.
 
@@ -45,6 +45,18 @@ The parameters are
 | RetrainingRate                  | Rate at which the Personalize should be retrained, defaults to **7 days** if not set.                                                      | No       |
 
 (*) One of the datasources needs to be updated, otherwise, creating a new solution version does not make sense. For the datasource that should be updated, the dataset ARN as well as the S3 path are required.
+
+### Advanced use
+The parameter `--stack-name` in `Makefile` determines the name of the stack. You can modify it by setting the environment variable `STACK_NAME` before running make, like so
+```bash
+$ STACK_NAME=personalize-retraining-2 make
+```
+Parameters by default are loaded form `parameters.cfg`. You can override this behaviour by setting the `PARAMS_FILE` environment variable.
+The combination of the above two options, allows you to practically run multiple instances of retraining automation in parallel. Let's say you have a dataset for your production enviroment and another one for your staging:
+```bash
+$ STACK_NAME=personalize-retraining-staging PARAMS_FILE=parameters.staging.cfg make  # For staging
+$ STACK_NAME=personalize-retraining-prod PARAMS_FILE=parameters.prod.cfg make  # For prod
+```
 
 ## Components of this sample
 


### PR DESCRIPTION
*Issue #, if available:* #1

*Description of changes:* Specify the parameters file and stack name using environment variables. They have a default in the Makefile and can be overridden by setting the environment variables `PARAMS_FILE` and `STACK_NAME`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
